### PR TITLE
Do not generate attributes via AR::Attributes

### DIFF
--- a/lib/rbs_activemodel/active_model.rb
+++ b/lib/rbs_activemodel/active_model.rb
@@ -97,7 +97,7 @@ module RbsActivemodel
       end
 
       def attributes
-        return "" unless klass < ::ActiveModel::Attributes || klass < ::ActiveRecord::Attributes
+        return "" unless klass < ::ActiveModel::Attributes
 
         # @type var model: untyped
         model = klass

--- a/spec/rbs_activemodel/active_model_spec.rb
+++ b/spec/rbs_activemodel/active_model_spec.rb
@@ -121,19 +121,8 @@ RSpec.describe RbsActivemodel::ActiveModel do
             attribute :name, :string
           end
         end
-        let(:expected) do
-          <<~RBS
-            class Foo < ::ActiveRecord::Base
-              def id: () -> Integer?
-              def id=: (Integer? value) -> Integer?
 
-              def name: () -> String?
-              def name=: (String? value) -> String?
-            end
-          RBS
-        end
-
-        it { is_expected.to eq expected }
+        it { is_expected.to eq nil }
       end
     end
   end


### PR DESCRIPTION
The attributes defined in ActiveRecord models becomes targets of this gem and ignored now.