### PR TITLE
Make reader methods pure

### DIFF
--- a/lib/rbs_activemodel/active_model.rb
+++ b/lib/rbs_activemodel/active_model.rb
@@ -113,6 +113,7 @@ module RbsActivemodel
                       end
           suffix = "?" unless required_attribute?(name)
           <<~RBS
+            %a{pure}
             def #{name}: () -> #{type_name}#{suffix}
             def #{name}=: (#{type_name}#{suffix} value) -> #{type_name}#{suffix}
           RBS

--- a/spec/rbs_activemodel/active_model_spec.rb
+++ b/spec/rbs_activemodel/active_model_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe RbsActivemodel::ActiveModel do
                 include ::ActiveModel::Validations
                 extend ::ActiveModel::Validations::ClassMethods
 
+                %a{pure}
                 def name: () -> String
                 def name=: (String value) -> String
               end
@@ -102,9 +103,11 @@ RSpec.describe RbsActivemodel::ActiveModel do
                 include ::ActiveModel::Attributes
                 extend ::ActiveModel::Attributes::ClassMethods
 
+                %a{pure}
                 def age: () -> Integer?
                 def age=: (Integer? value) -> Integer?
 
+                %a{pure}
                 def created_at: () -> (DateTime | ActiveSupport::TimeWithZone)?
                 def created_at=: ((DateTime | ActiveSupport::TimeWithZone)? value) -> (DateTime | ActiveSupport::TimeWithZone)?
               end


### PR DESCRIPTION
To support type narrowing by Steep, this adds `%a{pure}` annotation to all reader methods.