### PR TITLE
Introduce rubocop-rake plugin

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
 
 plugins:
   - rubocop-numbered-params
+  - rubocop-rake
   - rubocop-rbs_inline
 
 Layout/LeadingCommentSpace:

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ group :development do
   gem "rspec-daemon", require: false
   gem "rubocop", "~> 1.88"
   gem "rubocop-numbered-params", require: false
+  gem "rubocop-rake", require: false
   gem "rubocop-rbs_inline", require: false
   gem "ruby-lsp-rspec", require: false
   gem "steep", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,6 +180,9 @@ GEM
     rubocop-numbered-params (1.0.0)
       lint_roller (~> 1.0)
       rubocop (>= 1.72.1)
+    rubocop-rake (0.7.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.72.1)
     rubocop-rbs_inline (1.5.5)
       lint_roller (~> 1.1)
       rbs-inline
@@ -242,6 +245,7 @@ DEPENDENCIES
   rspec-daemon
   rubocop (~> 1.88)
   rubocop-numbered-params
+  rubocop-rake
   rubocop-rbs_inline
   ruby-lsp-rspec
   sqlite3


### PR DESCRIPTION
Add the `rubocop-rake` plugin so this repository lints its Rake tasks, aligning it with the other repositories that already enable the full plugin set (numbered-params, rake, rbs_inline, rspec).

- Add `rubocop-rake` to the Gemfile and lockfile
- Register it under `plugins:` in `.rubocop.yml`

No new offenses are reported by `rubocop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)