### PR TITLE
Introduce rubocop-rspec plugin

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ plugins:
   - rubocop-numbered-params
   - rubocop-rake
   - rubocop-rbs_inline
+  - rubocop-rspec
 
 Layout/LeadingCommentSpace:
   AllowRBSInlineAnnotation: true
@@ -23,6 +24,9 @@ Metrics/CyclomaticComplexity:
 
 Metrics/MethodLength:
   Max: 20
+
+RSpec/NestedGroups:
+  Max: 5
 
 Style/Documentation:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ group :development do
   gem "rubocop-numbered-params", require: false
   gem "rubocop-rake", require: false
   gem "rubocop-rbs_inline", require: false
+  gem "rubocop-rspec", require: false
   gem "ruby-lsp-rspec", require: false
   gem "steep", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,10 @@ GEM
       lint_roller (~> 1.1)
       rbs-inline
       rubocop (>= 1.72.1, < 2.0)
+    rubocop-rspec (3.10.2)
+      lint_roller (~> 1.1)
+      regexp_parser (>= 2.0)
+      rubocop (~> 1.86, >= 1.86.2)
     ruby-lsp (0.26.9)
       language_server-protocol (~> 3.17.0)
       prism (>= 1.2, < 2.0)
@@ -247,6 +251,7 @@ DEPENDENCIES
   rubocop-numbered-params
   rubocop-rake
   rubocop-rbs_inline
+  rubocop-rspec
   ruby-lsp-rspec
   sqlite3
   steep

--- a/spec/rbs_activemodel/active_model_spec.rb
+++ b/spec/rbs_activemodel/active_model_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe RbsActivemodel::ActiveModel do
       stub_const("Foo", klass)
     end
 
-    context "When class is not a activemodel class" do
+    context "when class is not a activemodel class" do
       let(:klass) { Class.new }
 
-      it { is_expected.to eq nil }
+      it { is_expected.to be_nil }
     end
 
-    context "When class is a activemodel class" do
-      context "When the class includes ActiveModel::Model" do
+    context "when class is a activemodel class" do
+      context "when the class includes ActiveModel::Model" do
         let(:klass) do
           Class.new do
             include ActiveModel::Model
@@ -41,7 +41,7 @@ RSpec.describe RbsActivemodel::ActiveModel do
         it { is_expected.to eq expected }
       end
 
-      context "When the class includes ActiveModel::Validations" do
+      context "when the class includes ActiveModel::Validations" do
         let(:klass) do
           Class.new do
             include ActiveModel::Validations
@@ -59,8 +59,8 @@ RSpec.describe RbsActivemodel::ActiveModel do
         it { is_expected.to eq expected }
       end
 
-      context "When the class includes ActiveModel::Attributes" do
-        context "When the attribute is defined as required (presence)" do
+      context "when the class includes ActiveModel::Attributes" do
+        context "when the attribute is defined as required (presence)" do
           let(:klass) do
             Class.new do
               include ActiveModel::Attributes
@@ -89,7 +89,7 @@ RSpec.describe RbsActivemodel::ActiveModel do
           it { is_expected.to eq expected }
         end
 
-        context "When the attribute is defined as having defaults" do
+        context "when the attribute is defined as having defaults" do
           let(:klass) do
             Class.new do
               include ActiveModel::Attributes
@@ -118,7 +118,7 @@ RSpec.describe RbsActivemodel::ActiveModel do
           it { is_expected.to eq expected }
         end
 
-        context "When the attribute is defined as optional" do
+        context "when the attribute is defined as optional" do
           let(:klass) do
             Class.new do
               include ActiveModel::Attributes
@@ -148,8 +148,8 @@ RSpec.describe RbsActivemodel::ActiveModel do
         end
       end
 
-      context "When the class includes ActiveModel::SecurePassword" do
-        context "When the class calls has_secure_password without any options" do
+      context "when the class includes ActiveModel::SecurePassword" do
+        context "when the class calls has_secure_password without any options" do
           let(:klass) do
             Class.new do
               include ActiveModel::SecurePassword
@@ -181,7 +181,7 @@ RSpec.describe RbsActivemodel::ActiveModel do
           it { is_expected.to eq expected }
         end
 
-        context "When the class calls has_secure_password with attribute name" do
+        context "when the class calls has_secure_password with attribute name" do
           let(:klass) do
             Class.new do
               include ActiveModel::SecurePassword
@@ -212,8 +212,8 @@ RSpec.describe RbsActivemodel::ActiveModel do
         end
       end
 
-      context "When the class is a subclass of ActiveRecord::Base" do
-        context "When the class calls has_secure_password" do
+      context "when the class is a subclass of ActiveRecord::Base" do
+        context "when the class calls has_secure_password" do
           let(:klass) do
             Class.new(ActiveRecord::Base) do
               has_secure_password
@@ -238,14 +238,14 @@ RSpec.describe RbsActivemodel::ActiveModel do
           it { is_expected.to eq expected }
         end
 
-        context "When the class does not call has_secure_password" do
+        context "when the class does not call has_secure_password" do
           let(:klass) do
             Class.new(ActiveRecord::Base) do
               attribute :name, :string
             end
           end
 
-          it { is_expected.to eq nil }
+          it { is_expected.to be_nil }
         end
       end
     end


### PR DESCRIPTION
Add the `rubocop-rspec` plugin so this repository lints its specs, completing the full plugin set (numbered-params, rake, rbs_inline, rspec) shared across the sibling repositories.

- Add `rubocop-rspec` to the Gemfile and lockfile
- Register it under `plugins:` in `.rubocop.yml`
- Configure `RSpec/NestedGroups` with the same setting used across the sibling repositories
- Reword `context` descriptions to lowercase `when …` to satisfy `RSpec/ContextWording` (matching the sibling specs)
- Replace `eq nil` with `be_nil` (`RSpec/BeEq` / `RSpec/BeNil`)

`rubocop` reports no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)