### PR TITLE
Align .rubocop.yml with shared skeleton baseline

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,7 @@
+# NOTE: Rules are sorted in ASCII order.
+
 AllCops:
+  NewCops: enable
   TargetRubyVersion: 3.2
 
 plugins:
@@ -7,9 +10,17 @@ plugins:
   - rubocop-rbs_inline
   - rubocop-rspec
 
+# Layout
 Layout/LeadingCommentSpace:
   AllowRBSInlineAnnotation: true
   AllowSteepAnnotation: true
+
+Layout/LineLength:
+  Max: 120
+
+# Metrics
+Metrics/AbcSize:
+  Max: 20
 
 Metrics/BlockLength:
   Exclude:
@@ -17,20 +28,31 @@ Metrics/BlockLength:
     - "spec/**/*.rb"
 
 Metrics/ClassLength:
-  Max: 150
+  Max: 200
 
 Metrics/CyclomaticComplexity:
   Max: 10
 
 Metrics/MethodLength:
-  Max: 20
+  Max: 30
+
+# RSpec
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/NamedSubject:
+  Enabled: false
 
 RSpec/NestedGroups:
   Max: 5
 
-Style/Documentation:
-  Enabled: false
-
+# RbsInline
 Style/RbsInline/MissingTypeAnnotation:
   EnforcedStyle: doc_style_and_return_annotation
 
@@ -39,6 +61,22 @@ Style/RbsInline/RedundantTypeAnnotation:
 
 Style/RbsInline/RequireRbsInlineComment:
   EnforcedStyle: never
+
+# Style
+Style/AccessorGrouping:
+  Enabled: false
+
+Style/CommentedKeyword:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: always
+
+Style/RedundantFormat:
+  Enabled: false
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/Gemfile
+++ b/Gemfile
@@ -18,5 +18,6 @@ group :development do
   gem "rubocop-rbs_inline", require: false
   gem "rubocop-rspec", require: false
   gem "ruby-lsp-rspec", require: false
+  gem "sqlite3"
   gem "steep", require: false
 end

--- a/lib/rbs_activemodel/active_model.rb
+++ b/lib/rbs_activemodel/active_model.rb
@@ -71,7 +71,7 @@ module RbsActivemodel
       def format(rbs) #: String
         parsed = RBS::Parser.parse_signature(rbs)
         StringIO.new.tap do |out|
-          RBS::Writer.new(out: out).write(parsed[1] + parsed[2])
+          RBS::Writer.new(out:).write(parsed[1] + parsed[2])
         end.string
       end
 
@@ -102,7 +102,7 @@ module RbsActivemodel
         methods = klass.instance_methods.grep(/^authenticate_/)
         @secure_password ||= methods.filter_map do |method_name|
           attribute = method_name.to_s.split("_").last
-          next unless klass.instance_methods.include?(:"#{attribute}_confirmation")
+          next unless klass.method_defined?(:"#{attribute}_confirmation")
 
           <<~RBS
             attr_reader #{attribute}: String?

--- a/lib/rbs_activemodel/rake_task.rb
+++ b/lib/rbs_activemodel/rake_task.rb
@@ -10,7 +10,7 @@ module RbsActivemodel
 
     # @rbs name: Symbol
     # @rbs &block: ?(self) -> void
-    def initialize(name = :'rbs:activemodel', &block) #: void
+    def initialize(name = :"rbs:activemodel", &block) #: void
       super()
 
       @name = name

--- a/rbs_activemodel.gemspec
+++ b/rbs_activemodel.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = spec.homepage
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   gemspec = File.basename(__FILE__)
   spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
@@ -29,12 +30,10 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { File.basename(_1) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activemodel", ">= 7.1"
-  spec.add_runtime_dependency "activerecord"
-  spec.add_runtime_dependency "railties"
-  spec.add_runtime_dependency "rbs"
-
-  spec.add_development_dependency "sqlite3"
+  spec.add_dependency "activemodel", ">= 7.1"
+  spec.add_dependency "activerecord"
+  spec.add_dependency "railties"
+  spec.add_dependency "rbs"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
## Summary

Align this repository's `.rubocop.yml` with the shared `init-ruby-project`
skeleton so linting rules are consistent across all Ruby repositories, and
fix the offenses that the aligned config surfaces.

## Config changes

Fill in cops that were missing from the baseline:

- `AllCops/NewCops: enable`
- `Layout/LineLength: 120`
- `Metrics/AbcSize: 20`
- `RSpec/ExampleLength`, `RSpec/MultipleMemoizedHelpers`,
  `RSpec/MultipleExpectations`, `RSpec/NamedSubject`
- `Style/AccessorGrouping`, `Style/CommentedKeyword`, `Style/HashSyntax`

Relax project-local settings that were stricter than the baseline:

- `Metrics/MethodLength`: 20 → 30
- `Metrics/ClassLength`: 150 → 200

Project-specific extensions (`Metrics/CyclomaticComplexity`,
`Metrics/BlockLength` excludes) are preserved. Rules are sorted in ASCII
order to match the skeleton.

## Code changes (offenses surfaced by the new cops)

- `active_model.rb`: use `out:` shorthand and `method_defined?`
- `rake_task.rb`: use a double-quoted symbol
- `rbs_activemodel.gemspec`: set `rubygems_mfa_required`, use
  `add_dependency`, and move the `sqlite3` development dependency to the
  `Gemfile`
- Disable `Style/RedundantFormat`: the local `format` method is not
  `Kernel#format`, so the cop is a false positive here

Verified locally with `rubocop` (no offenses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)